### PR TITLE
Refactor pbibamio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ setuptools_cython*
 .eggs
 pbtranscript/ice/C/*.cpp
 pbtranscript/ice/C/*.c
+tests/out
+tests/regression/current-run

--- a/tests/cram/classify_dataset_input.t
+++ b/tests/cram/classify_dataset_input.t
@@ -1,0 +1,15 @@
+#Test pbtranscript cluster, bam input.
+
+  $ . $TESTDIR/setup.sh
+
+  $ D=$SIVDATDIR/sa3
+  $ BAS=$D/bam.subreadset.xml
+  $ CCS=$D/tinyccsbam.consensusreadset.xml # use a smaller dataset other than $D/ccsbam.consensusset.xml
+  $ NFL=$D/nfl.contigset.xml
+  $ FLNC=$D/flnc.contigset.xml
+
+  $ CLASSIFYOUTDIR=$OUTDIR/test_classify
+  $ OUTFA=$OUTDIR/classify_out_1.fasta
+  $ OUTXML=$OUTDIR/classify_out_1.contigset.xml
+  $ rm -rf $OUTFA $OUTXML $OUTCSV $OUTSUMMARY $CLASSIFYOUTDIR
+  $ pbtranscript classify $CCS $OUTXML -d $CLASSIFYOUTDIR --cpus 8

--- a/tests/cram/cluster_dataset_input.t
+++ b/tests/cram/cluster_dataset_input.t
@@ -8,12 +8,6 @@
   $ NFL=$D/nfl.contigset.xml
   $ FLNC=$D/flnc.contigset.xml
 
-  $ CLASSIFYOUTDIR=$OUTDIR/test_classify
-  $ OUTFA=$OUTDIR/classify_out_1.fasta
-  $ OUTXML=$OUTDIR/classify_out_1.contigset.xml
-  $ rm -rf $OUTFA $OUTXML $OUTCSV $OUTSUMMARY $CLASSIFYOUTDIR
-  $ pbtranscript classify $CCS $OUTXML -d $CLASSIFYOUTDIR --cpus 8
-
   $ OFA=$OUTDIR/cluster_bam_out.contigset.xml
   $ OD=$OUTDIR/test_cluster_dataset
 

--- a/tests/unit/test_BamWriter.py
+++ b/tests/unit/test_BamWriter.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """Test classes defined within pbtranscript.io.PbiBamIO."""
 import unittest
 import os.path as op
@@ -12,7 +14,7 @@ from pbcore.util.Process import backticks
 
 def compareBamRecords(this, other):
     """Compare this (a BamAlignment object) with other
-      (a PbiBamReader.BamZmwRead object)"""
+      (a BamZmwRead object)"""
     assert(isinstance(this, BamAlignment) and
            isinstance(other, BamZmwRead))
     return (this.readName == other.readName    and


### PR DESCRIPTION
bug 32948
    Refactor BamCollection.
    Remove assumptions that input bam of BamCollection
    objects must only contain reads from a single movie.
    Remove class PbiBamReader.
    Refactored code is ~20% faster than before.
