### PR TITLE
Minor update

### DIFF
--- a/pbtranscript/ice/IceQuiver.py
+++ b/pbtranscript/ice/IceQuiver.py
@@ -61,10 +61,9 @@ class IceQuiver(IceFiles):
             errMsg = "Log dir {l} is not an existing directory.".\
                 format(l=self.log_dir)
         elif self.bas_fofn is None:
-            errMsg = "Please specify bas_fofn (e.g. input.fofn)."
+            errMsg = "Please specify subreads file (e.g., --bas_fofn=input.fofn|subreadset.xml)."
         elif not nfs_exists(self.bas_fofn):
-            errMsg = "bas_fofn {f} ".format(f=self.bas_fofn) + \
-                     "which specifies subreads does not exist."
+            errMsg = "Specified subreads file (bas_fofn={f}) does not exist.".format(f=self.bas_fofn)
         elif not nfs_exists(self.nfl_all_pickle_fn):
             #"output/map_noFL/noFL.ALL.partial_uc.pickle"):
             errMsg = "Pickle file {f} ".format(f=self.nfl_all_pickle_fn) + \
@@ -76,8 +75,8 @@ class IceQuiver(IceFiles):
                      "which assigns full-length non-chimeric reads to " + \
                      "isoforms does not exist."
 
-
-        if guess_file_format(self.bas_fofn) is not FILE_FORMATS.BAM:
+        if self.bas_fofn is not None and \
+            guess_file_format(self.bas_fofn) is not FILE_FORMATS.BAM:
             # No need to convert subreads.bam to fasta
             if self.fasta_fofn is None:
                 errMsg = "Please make sure ice_make_fasta_fofn has " + \

--- a/pbtranscript/io/PbiBamIO.py
+++ b/pbtranscript/io/PbiBamIO.py
@@ -51,7 +51,7 @@ class BamZmw(object):
         return self.bamRecords[0].qName.split("/")[0]
 
     @property
-    def IsCCS(self):
+    def isCCS(self):
         """True if this zmw has ccs reads; False otherwise."""
         return self._isCCS
 
@@ -68,7 +68,7 @@ class BamZmw(object):
     def ccsRead(self):
         """Return ccs read of this zmw. None if this zmw only
         contains subreads."""
-        if not self.IsCCS:
+        if not self.isCCS:
             return None
         assert len(self.bamRecords) == 1
         return BamCCSZmwRead(self, self.bamRecords[0], self.holeNumber)
@@ -76,7 +76,7 @@ class BamZmw(object):
     @property
     def subreads(self):
         """Return a list of subreads of this zmw."""
-        if self.IsCCS:
+        if self.isCCS:
             return []
         return [BamZmwRead(self, _record, self.holeNumber)
                 for _record in self.bamRecords]
@@ -95,7 +95,7 @@ class BamZmw(object):
             else:
                 _record = self.bamRecords[0]
                 readStart, readEnd = 0, _record.qLen
-                if not self.IsCCS:
+                if not self.isCCS:
                     readStart, readEnd = _record.qStart, _record.qEnd
         else:
             _record = _findBamRecord(self.bamRecords, readStart, readEnd)

--- a/pbtranscript/tasks/ice_cleanup.py
+++ b/pbtranscript/tasks/ice_cleanup.py
@@ -15,6 +15,7 @@ from pbcommand.models import FileTypes
 from pbcommand.utils import setup_log
 
 from pbtranscript.Utils import execute
+from pbtranscript.ice.IceFiles import IceFiles
 from pbtranscript.PBTranscriptOptions import get_base_contract_parser
 from pbtranscript.tasks.TPickles import ChunkTasksPickle, ClusterChunkTask
 
@@ -69,10 +70,17 @@ def resolved_tool_contract_runner(rtc):
     sentinel_out = rtc.task.output_files[0]
     with open(sentinel_out, 'w') as writer:
         for task in p:
-            tmp_dir = op.join(task.cluster_out_dir, "tmp")
-            log.info("Cleaning up, removing task.cluster_out_dir %s", tmp_dir)
+            icef = IceFiles(prog_name="ice_cleanup",
+                            root_dir=task.cluster_out_dir)
+            tmp_dir = icef.tmp_dir
+            log.info("Cleaning up, removing %s", tmp_dir)
             writer.write("removing %s\n" % tmp_dir)
             execute("rm -rf %s" % tmp_dir)
+
+            quivered_dir = icef.quivered_dir
+            log.info("Cleaning up, removing %s", quivered_dir)
+            writer.write("removing %s\n" % quivered_dir)
+            execute("rm -rf %s" % quivered_dir)
 
 
 def main():


### PR DESCRIPTION
Add comprehensive error message for 'ice_quiver.py all'.
Clean up more intermediate files under cluster_out/quivered (which haven't caused smrtlink service issues but are nice to be cleaned up). Note that intermediate files under cluster_out/quivered can be recovered by command 'ice_quiver.py all --bas_fofn=datasets.xml'
use uniform function names (e,g, uses isCCS uniformly instead of using IsCCS in some classes and isCCS in other classes).
