### PR TITLE
Add tofu_wrap.py to pbtranscript

### DIFF
--- a/pbtranscript/ClusterOptions.py
+++ b/pbtranscript/ClusterOptions.py
@@ -235,7 +235,7 @@ class IceQuiverHQLQOptions(object):
 
     """Define HQ/LQ isoforms related options"""
 
-    def __init__(self, qv_trim_5=200, qv_trim_3=50, hq_quiver_min_accuracy=0.99,
+    def __init__(self, qv_trim_5=100, qv_trim_3=30, hq_quiver_min_accuracy=0.99,
                  hq_isoforms_fa=None, hq_isoforms_fq=None,
                  lq_isoforms_fa=None, lq_isoforms_fq=None,
                  hq_min_full_length_reads=2):

--- a/pbtranscript/PBTranscriptOptions.py
+++ b/pbtranscript/PBTranscriptOptions.py
@@ -38,8 +38,12 @@ class BaseConstants(object):
     HQ_QUIVER_MIN_ACCURACY_DEFAULT = 0.99
     QV_TRIM_FIVEPRIME_ID = "pbtranscript.task_options.qv_trim_5p"
     QV_TRIM_FIVEPRIME_DEFAULT = 100
+    QV_TRIM_FIVEPRIME_DESC = "Ignore QV of n bases in the 5' end " + \
+            "(default %s)." % QV_TRIM_FIVEPRIME_DEFAULT
     QV_TRIM_THREEPRIME_ID = "pbtranscript.task_options.qv_trim_3p"
     QV_TRIM_THREEPRIME_DEFAULT = 30
+    QV_TRIM_THREEPRIME_DESC = "Ignore QV of n bases in the 3' end " + \
+            "(default %s)." % QV_TRIM_THREEPRIME_DEFAULT
     SAMPLE_NAME_ID = "pbtranscript.task_options.sample_name"
     SAMPLE_NAME_DEFAULT = ""
 
@@ -439,7 +443,7 @@ def add_ice_post_quiver_hq_lq_arguments(parser):
 def add_fofn_arguments(arg_parser, ccs_fofn=False, bas_fofn=False,
                        tool_contract_parser=None):
     """Add ccs_fofn, bas_fofn, fasta_fofn arguments."""
-    helpstr = "A FOFN of ccs.h5 or ccs.bam (e.g., ccs.fofn), " + \
+    helpstr = "A FOFN of ccs.h5, bam or dataset xml (e.g., ccs.fofn|bam|consensusreadset.xml), " + \
               "which contain quality values of consensus (CCS) reads. " + \
               "If not given, assume there is no QV information available."
     if ccs_fofn is True:
@@ -453,7 +457,7 @@ def add_fofn_arguments(arg_parser, ccs_fofn=False, bas_fofn=False,
             tool_contract_parser.add_input_file_type(FileTypes.DS_CCS,
                 "ccs_fofn", "CCS dataset", helpstr)
 
-    helpstr = "A FOFN of bax/bas.h5 or bam files (e.g., input.fofn), " + \
+    helpstr = "A FOFN of bax/bas.h5, bam or dataset xml (e.g., input.fofn|bam|subreadset.xml), " + \
               "which contain quality values of raw reads and subreads"
     if bas_fofn is True:
         arg_parser.add_argument("--bas_fofn",

--- a/pbtranscript/PBTranscriptOptions.py
+++ b/pbtranscript/PBTranscriptOptions.py
@@ -470,6 +470,13 @@ def add_fofn_arguments(arg_parser, ccs_fofn=False, bas_fofn=False,
             tool_contract_parser.add_input_file_type(FileTypes.DS_SUBREADS,
                 "subreads_fofn", "SubreadSet", helpstr)
 
+    helpstr = "A FOFN of trimmed subreads fasta (e.g. input.fasta.fofn)"
+    if fasta_fofn is True:
+        arg_parser.add_argument("--fasta_fofn",
+                                dest="fasta_fofn",
+                                type=validate_fofn,
+                                default=None,
+                                help=helpstr)
     return arg_parser
 
 
@@ -508,6 +515,11 @@ def add_nfl_fa_argument(arg_parser, positional=False, required=False,
         assert(required is True or required is False)
         arg_parser.add_argument("--nfl_fa", type=str, dest="nfl_fa",
                                 required=required, help=helpstr)
+
+    arg_parser.add_argument("--nfl_reads_per_split", type=int,
+                            dest="nfl_reads_per_split", default=60000,
+                            help="Number of nFL reads per split file (default: 60000)")
+
     if tool_contract_parser is not None:
         tool_contract_parser.add_input_file_type(FileTypes.DS_CONTIG,
             "nfl_fa", "FASTA or ContigSet file", helpstr)
@@ -589,7 +601,7 @@ def add_cluster_arguments(parser):
     arg_parser = add_nfl_fa_argument(arg_parser, positional=False,
                                      required=False,
                                      tool_contract_parser=tool_contract_parser)
-    arg_parser = add_fofn_arguments(arg_parser, ccs_fofn=True, bas_fofn=True,
+    arg_parser = add_fofn_arguments(arg_parser, ccs_fofn=True, bas_fofn=True, fasta_fofn=True,
                                     tool_contract_parser=tool_contract_parser)
 
     helpstr = "Directory to store temporary and output cluster files." + \
@@ -609,7 +621,7 @@ def add_cluster_arguments(parser):
 
     # Add Sge options
     arg_parser = add_sge_arguments(arg_parser, blasr_nproc=True,
-                                   quiver_nproc=True)
+                                   quiver_nproc=True, gcon_nproc=True)
 
     # Add IceQuiver HQ/LQ options.
     arg_parser = add_ice_post_quiver_hq_lq_arguments(arg_parser)
@@ -622,7 +634,7 @@ def add_subset_arguments(parser):
         name="ContigSet",
         description="Input FASTA file (usually isoseq_draft.fasta)")
     parser.add_output_file_type(FileTypes.DS_CONTIG, "outFN",
-        name="Output ContigSet",
+        name="Output FASTA or ContigSet",
         description="Output FASTA file",
         default_name="pbtranscript_subset_out")
 

--- a/pbtranscript/RunnerUtils.py
+++ b/pbtranscript/RunnerUtils.py
@@ -242,7 +242,7 @@ def sge_job_runner(cmds_list, script_files,
 
       rescue - whether or not to rescue a qdel-ed job.
                None - no rescue
-               locall - yes, run it locally exactly once
+               locally - yes, run it locally exactly once
                sge - yes, run it through sge, try multiple times until suceed
       rescue_times - maximum times of rescuing a qdel-ed job.
 

--- a/pbtranscript/collapsing/CollapseIsoforms.py
+++ b/pbtranscript/collapsing/CollapseIsoforms.py
@@ -20,8 +20,7 @@ Note that Branch does not merge fuzzy junctions
 import logging
 import os.path as op
 
-
-from pbtranscript.Utils import ln
+from pbtranscript.Utils import ln, realpath
 from pbtranscript.io import iter_gmap_sam, ContigSetReaderWrapper, \
         CollapseGffWriter, GroupWriter, parse_ds_filename
 from pbtranscript.collapsing.common import CollapsedFiles
@@ -208,9 +207,9 @@ class CollapseIsoformsRunner(CollapsedFiles):
               bad_gff_fn=self.bad_unfuzzy_gff_fn,
               group_fn=self.unfuzzy_group_fn)
 
-        logging.info("Good unfuzzy isoforms written to: %s", self.good_unfuzzy_gff_fn)
-        logging.info("Bad unfuzzy isoforms written to: %s", self.bad_unfuzzy_gff_fn)
-        logging.info("Unfuzzy isoform groups written to: %s", self.unfuzzy_group_fn)
+        logging.info("Good unfuzzy isoforms written to: %s", realpath(self.good_unfuzzy_gff_fn))
+        logging.info("Bad unfuzzy isoforms written to: %s", realpath(self.bad_unfuzzy_gff_fn))
+        logging.info("Unfuzzy isoform groups written to: %s", realpath(self.unfuzzy_group_fn))
 
         if self.shall_collapse_fuzzy_junctions:
             logging.info("Further collapsing fuzzy junctions.")
@@ -222,9 +221,9 @@ class CollapseIsoformsRunner(CollapsedFiles):
                                      allow_extra_5exon=self.allow_extra_5exon,
                                      max_fuzzy_junction=self.max_fuzzy_junction)
 
-            logging.info("Good fuzzy isoforms written to: %s", self.good_fuzzy_gff_fn)
-            logging.info("Bad fuzzy isoforms written to: %s", self.bad_fuzzy_gff_fn)
-            logging.info("Fuzzy isoform groups written to: %s", self.fuzzy_group_fn)
+            logging.info("Good fuzzy isoforms written to: %s", realpath(self.good_fuzzy_gff_fn))
+            logging.info("Bad fuzzy isoforms written to: %s", realpath(self.bad_fuzzy_gff_fn))
+            logging.info("Fuzzy isoform groups written to: %s", realpath(self.fuzzy_group_fn))
             ln(self.good_fuzzy_gff_fn, self.good_gff_fn)
             ln(self.good_fuzzy_gff_fn, self.gff_fn)
             ln(self.fuzzy_group_fn, self.group_fn)
@@ -245,8 +244,8 @@ class CollapseIsoformsRunner(CollapsedFiles):
                  pick_least_err_instead=pick_least_err_instead,
                  bad_gff_filename=self.bad_gff_fn)
 
-        logging.info("Ignored IDs written to: %s", self.ignored_ids_txt_fn)
-        logging.info("Output GFF written to: %s", self.gff_fn)
-        logging.info("Output Group TXT written to: %s", self.group_fn)
-        logging.info("Output collapsed isoforms written to: %s", self.rep_fn(self.suffix))
-        logging.info("Arguments: %s", self.arg_str())
+        logging.info("Ignored IDs written to: %s", realpath(self.ignored_ids_txt_fn))
+        logging.info("Output GFF written to: %s", realpath(self.gff_fn))
+        logging.info("Output Group TXT written to: %s", realpath(self.group_fn))
+        logging.info("Output collapsed isoforms written to: %s", realpath(self.rep_fn(self.suffix)))
+        logging.info("CollapseIsoforms Arguments: %s", self.arg_str())

--- a/pbtranscript/ice/IceFiles.py
+++ b/pbtranscript/ice/IceFiles.py
@@ -19,7 +19,7 @@ class IceFiles(object):
 
     def __init__(self, prog_name, root_dir,
                  bas_fofn=None, ccs_fofn=None, fasta_fofn=None,
-                 no_log_f=False, tmp_dir=None):
+                 no_log_f=False, tmp_dir=None, make_dirs=True):
         """
         prog_name --- name of a sub-class
         root_dir --- root directory of the whole project. There will be
@@ -52,11 +52,12 @@ class IceFiles(object):
         self.ccs_fofn = real_ppath(ccs_fofn)
         self.fasta_fofn = real_ppath(fasta_fofn)
 
-        mkdir(self.root_dir)
-        mkdir(self.tmp_dir)
-        mkdir(self.log_dir)
-        mkdir(self.script_dir)
-        mkdir(self.out_dir)
+        if make_dirs is True:
+            mkdir(self.root_dir)
+            mkdir(self.tmp_dir)
+            mkdir(self.log_dir)
+            mkdir(self.script_dir)
+            mkdir(self.out_dir)
 
         self.no_log_f = no_log_f
         if not no_log_f:

--- a/pbtranscript/ice/IceQuiverAll.py
+++ b/pbtranscript/ice/IceQuiverAll.py
@@ -162,7 +162,7 @@ def add_ice_quiver_all_arguments(parser):
     arg_parser = add_fofn_arguments(arg_parser, bas_fofn=True,
         tool_contract_parser=parser.tool_contract_parser)
     tcp_parser = add_cluster_summary_report_arguments(_wrap_parser(arg_parser))
-    arg_parser = add_ice_post_quiver_hq_lq_arguments(_wrap_parser(arg_parser))
+    arg_parser = add_ice_post_quiver_hq_lq_arguments(arg_parser)
     arg_parser = add_sge_arguments(arg_parser, quiver_nproc=True,
                                    blasr_nproc=True)
     arg_parser = add_tmp_dir_argument(arg_parser)

--- a/pbtranscript/ice/IceQuiverPostprocess.py
+++ b/pbtranscript/ice/IceQuiverPostprocess.py
@@ -152,10 +152,11 @@ class IceQuiverPostprocess(IceFiles):
 
     def __init__(self, root_dir, ipq_opts,
                  use_sge=False, quit_if_not_done=True,
-                 summary_fn=None, report_fn=None):
+                 summary_fn=None, report_fn=None,
+                 no_log_f=False, make_dirs=True):
         super(IceQuiverPostprocess, self).__init__(
                 prog_name="ice_quiver_postprocess",
-                root_dir=root_dir)
+                root_dir=root_dir, no_log_f=no_log_f, make_dirs=make_dirs)
         self.use_sge = use_sge
         self.quit_if_not_done = quit_if_not_done
 
@@ -190,8 +191,6 @@ class IceQuiverPostprocess(IceFiles):
 
         self.report_fn = report_fn
         self.summary_fn = summary_fn
-
-        self.validate_inputs()
 
     def get_existing_binned_quivered_fq(self):
         """Return all existing quivered fq files for binned clusters."""
@@ -421,6 +420,8 @@ class IceQuiverPostprocess(IceFiles):
         """Check all quiver jobs are running, failed or done. Write high-quality
         consensus and low-quality consensus to all_quivered.good|bad.fasta|fastq.
         """
+        self.validate_inputs()
+
         job_stats = self.check_quiver_jobs_completion()
         self.add_log("quiver job status: {s}".format(s=job_stats))
 

--- a/pbtranscript/tasks/collapse_mapped_isoforms.py
+++ b/pbtranscript/tasks/collapse_mapped_isoforms.py
@@ -37,24 +37,24 @@ class Constants(object):
 
     MIN_ALN_COVERAGE_ID = "pbtranscript.task_options.min_gmap_aln_coverage"
     MIN_ALN_COVERAGE_DEFAULT = 0.99
-    MIN_ALN_COVERAGE_DESC = "Min query coverage to analyze a GMAP alignment"
+    MIN_ALN_COVERAGE_DESC = "Min query coverage to analyze a GMAP alignment (default: %s)" % MIN_ALN_COVERAGE_DEFAULT
 
     MIN_ALN_IDENTITY_ID = "pbtranscript.task_options.min_gmap_aln_identity"
     MIN_ALN_IDENTITY_DEFAULT = 0.95
-    MIN_ALN_IDENTITY_DESC = "Min identity to analyze a GMAP alignment"
+    MIN_ALN_IDENTITY_DESC = "Min identity to analyze a GMAP alignment (default: %s)" % MIN_ALN_IDENTITY_DEFAULT
 
     MAX_FUZZY_JUNCTION_ID = "pbtranscript.task_options.max_fuzzy_junction"
     MAX_FUZZY_JUNCTION_DEFAULT = 5
-    MAX_FUZZY_JUNCTION_DESC = "Max edit distance between merge-able fuzzy junctions "
+    MAX_FUZZY_JUNCTION_DESC = "Max edit distance between merge-able fuzzy junctions (default: %s)" % MAX_FUZZY_JUNCTION_DEFAULT
 
     MIN_FLNC_COVERAGE_DEFAULT = 2
     MIN_FLNC_COVERAGE_DESC = "Minimum number of supportive FLNC reads " + \
-                             "only used for aligned FLNC reads, otherwise, result undefined."
+                             "only used for aligned FLNC reads, otherwise, result undefined (default: %s)" % MIN_FLNC_COVERAGE_DEFAULT
 
     ALLOW_EXTRA_5EXON_ID = "pbtranscript.task_options.allow_extra_5exon"
     ALLOW_EXTRA_5EXON_DEFAULT = False
     ALLOW_EXTRA_5EXON_DESC = "True: Collapse shorter 5' transcripts. " + \
-                             "False: Don't collapse shorter 5' transcripts "
+                             "False: Don't collapse shorter 5' transcripts (default: %s)" % ALLOW_EXTRA_5EXON_DEFAULT
 
     SKIP_5_EXON_ALT_DEFAULT = False
 
@@ -78,7 +78,7 @@ def add_collapse_mapped_isoforms_io_arguments(arg_parser):
 
 def add_collapse_mapped_isoforms_arguments(arg_parser):
     """Add arguments for collapse isoforms."""
-    coll_group = arg_parser.add_argument_group("collapse isoforms arguments")
+    coll_group = arg_parser.add_argument_group("Collapse isoforms arguments")
     coll_group.add_argument("-c", "--min_coverage", dest="min_aln_coverage",
                             default=Constants.MIN_ALN_COVERAGE_DEFAULT,
                             type=float, help=Constants.MIN_ALN_COVERAGE_DESC)

--- a/pbtranscript/tasks/filter_collapsed_isoforms.py
+++ b/pbtranscript/tasks/filter_collapsed_isoforms.py
@@ -19,7 +19,7 @@ from pbcommand.models import FileTypes
 from pbcommand.utils import setup_log
 
 from pbtranscript.PBTranscriptOptions import get_base_contract_parser
-from pbtranscript.Utils import rmpath, mv
+from pbtranscript.Utils import rmpath, mv, realpath
 from pbtranscript.filtering import filter_by_count, filter_out_subsets
 
 import pbtranscript.tasks.collapse_mapped_isoforms as ci
@@ -120,9 +120,9 @@ def args_runner(args):
         mv(tmp_out_gff_filename, out_gff_filename)
         mv(tmp_out_fq, out_fq)
 
-    logging.info("Filtered collapsed isoforms sequences written to %s", out_fq)
-    logging.info("Filtered collapsed isoforms abundance written to %s", out_abundance_filename)
-    logging.info("Filtered collapsed isoforms gff written to %s", out_gff_filename)
+    logging.info("Filtered collapsed isoforms sequences written to %s", realpath(out_fq))
+    logging.info("Filtered collapsed isoforms abundance written to %s", realpath(out_abundance_filename))
+    logging.info("Filtered collapsed isoforms gff written to %s", realpath(out_gff_filename))
     return 0
 
 

--- a/pbtranscript/tasks/map_isoforms_to_genome.py
+++ b/pbtranscript/tasks/map_isoforms_to_genome.py
@@ -25,10 +25,10 @@ class Constants(object):
     PARSER_DESC = __doc__
 
     GMAP_NAME_ID = "pbtranscript.task_options.gmap_name"
-    GMAP_NAME_DEFAULT = "SIRV"
+    GMAP_NAME_DEFAULT = None #"SIRV"
 
     GMAP_DB_ID = "pbtranscript.task_options.gmap_db"
-    GMAP_DB_DEFAULT = "/pbi/dept/secondary/siv/testdata/pbtranscript-unittest/data/gmap_db"
+    GMAP_DB_DEFAULT = None #"/pbi/dept/secondary/siv/testdata/isoseq/gmap_db"
 
     GMAP_NPROC_ID = "pbtranscript.task_options.gmap_nproc"
     GMAP_NPROC_DEFAULT = 24
@@ -52,15 +52,14 @@ def add_gmap_arguments(arg_parser):
     gmap_group = arg_parser.add_argument_group("GMAP arguments")
 
     helpstr = "GMAP DB name (default: %s)" % Constants.GMAP_NAME_DEFAULT
-    gmap_group.add_argument("--gmap_name", type=str,
-                            default=Constants.GMAP_NAME_DEFAULT,
+    gmap_group.add_argument("--gmap_name", type=str, default=Constants.GMAP_NAME_DEFAULT,
                             help=helpstr)
 
     helpstr = "GMAP DB location (default: %s)" % Constants.GMAP_DB_DEFAULT
     gmap_group.add_argument("--gmap_db", type=str,
                             default=Constants.GMAP_DB_DEFAULT, help=helpstr)
 
-    helpstr = "GMAP Reference Set file to overwrite GMAP DB name and location."
+    helpstr = "GMAP Reference Set file to overwrite GMAP DB name and location (default: None)."
     gmap_group.add_argument("--gmap_ds", type=str, default=None, help=helpstr)
 
     helpstr = "GMAP nproc (default: %s)" % Constants.GMAP_NPROC_DEFAULT

--- a/pbtranscript/tasks/post_mapping_to_genome.py
+++ b/pbtranscript/tasks/post_mapping_to_genome.py
@@ -25,7 +25,7 @@ from pbcommand.cli.core import pbparser_runner
 from pbcommand.models import FileTypes
 from pbcommand.utils import setup_log
 
-from pbtranscript.Utils import ln
+from pbtranscript.Utils import ln, realpath
 from pbtranscript.io import parse_ds_filename
 from pbtranscript.PBTranscriptOptions import get_base_contract_parser
 from pbtranscript.collapsing import CollapsedFiles, FilteredFiles, CollapseIsoformsRunner
@@ -160,26 +160,31 @@ def post_mapping_to_genome_runner(in_isoforms, in_sam, in_pickle,
                            max_fuzzy_junction=max_fuzzy_junction)
         fff = fft
 
-    # (5) ln outputs
-    ln(fff.filtered_rep_fn(out_suffix), out_isoforms)
-    ln(fff.filtered_gff_fn, out_gff)
-    if out_abundance is not None:
-        ln(fff.filtered_abundance_fn, out_abundance)
-    if out_group is not None:
-        ln(fff.group_fn, out_group)
-    if out_read_stat is not None:
-        ln(fff.read_stat_fn, out_read_stat)
+    # (5) ln outputs files
+    ln_pairs = [(fff.filtered_rep_fn(out_suffix), out_isoforms), # rep isoforms
+                (fff.filtered_gff_fn, out_gff), # gff annotation
+                (fff.filtered_abundance_fn, out_abundance), # abundance info
+                (fff.group_fn, out_group), # groups
+                (fff.read_stat_fn, out_read_stat)] # read stat info
+    for src, dst in ln_pairs:
+        if dst is not None:
+            ln(src, dst)
 
     logging.info("Filter arguments: min_count = %s, filter_out_subsets=%s",
                  min_count, filter_out_subsets)
-    logging.info("Collapsed and filtered isoform sequences written to %s", out_isoforms)
-    logging.info("Collapsed and filtered isoform annotations written to %s", out_gff)
+    logging.info("Collapsed and filtered isoform sequences written to %s",
+                 realpath(out_isoforms) if out_isoforms is not None else
+                 realpath(fff.filtered_rep_fn(out_suffix)))
+    logging.info("Collapsed and filtered isoform annotations written to %s",
+                 realpath(out_gff) if out_gff is not None else realpath(fff.filtered_gff_fn))
     logging.info("Collapsed and filtered isoform abundance info written to %s",
-                 out_abundance if out_abundance is not None else fff.filtered_abundance_fn)
+                 realpath(out_abundance) if out_abundance is not None else
+                 realpath(fff.filtered_abundance_fn))
     logging.info("Collapsed isoform groups written to %s",
-                 out_group if out_group is not None else fff.group_fn)
+                 realpath(out_group) if out_group is not None else realpath(fff.group_fn))
     logging.info("Read status of FL and nFL reads written to %s",
-                 out_read_stat if out_read_stat is not None else fff.read_stat_fn)
+                 realpath(out_read_stat) if out_read_stat is not None else
+                 realpath(fff.read_stat_fn))
 
 
 def args_runner(args):

--- a/pbtranscript/tofu_wrap.py
+++ b/pbtranscript/tofu_wrap.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python
+
+"""
+Script tofu_wrap.py is designed to analyze FL/nFL CCS reads of
+PacBio cDNA samples. It separates CCS reads into bins, applies
+Iterative Clustering and Error Correction (ICE) algorithm to
+get isoform clusters, calls Arrow (Quiver) to polish isoform
+clusters. If a GMAP reference genome database is provided,
+the tofu_wrap.py maps polished isoform clusters to reference
+genome, collapses redundant isoform clusters into groups and
+produce annotations of collapsed isoform groups in GFF, counts
+abundance of supportive FL and nFL CCS reads of collapsed groups,
+and filters collapsed groups based on abundance info.
+
+Procedure:
+    (1) separate flnc into bins
+    (2) apply 'pbtranscript cluster' to each bin
+    (3) merge polished isoform cluster from all bins
+    (4) collapse polished isoform clusters into groups
+    (5) count abundance info of collapsed groups
+    (6) filter collapsed groups based on abundance info
+"""
+
+import os.path as op
+
+import sys
+import argparse
+import logging
+import time
+
+from pbcommand.utils import setup_log
+from pbcommand.cli.core import pacbio_args_runner
+
+from pbtranscript.__init__ import get_version
+from pbtranscript.Utils import ln, mkdir, realpath, get_sample_name
+from pbtranscript.ClusterOptions import IceOptions, SgeOptions, IceQuiverHQLQOptions
+from pbtranscript.PBTranscriptOptions import add_nfl_fa_argument, \
+    add_fofn_arguments, add_ice_arguments, add_sge_arguments, \
+    add_ice_post_quiver_hq_lq_qv_arguments
+
+from pbtranscript.Cluster import Cluster
+from pbtranscript.CombineUtils import CombinedFiles, CombineRunner
+from pbtranscript.separate_flnc import SeparateFLNCRunner, SeparateFLNCBase
+
+from pbtranscript.ice.IceQuiverPostprocess import IceQuiverPostprocess
+from pbtranscript.ice.IceUtils import convert_fofn_to_fasta
+from pbtranscript.collapsing.CollapsingUtils import map_isoforms_and_sort
+from pbtranscript.tasks.map_isoforms_to_genome import gmap_db_and_name_from_ds
+from pbtranscript.tasks.post_mapping_to_genome import add_post_mapping_to_genome_arguments, \
+        post_mapping_to_genome_runner
+from pbtranscript.tasks.separate_flnc import add_separate_flnc_arguments
+from pbtranscript.tasks.map_isoforms_to_genome import add_gmap_arguments
+
+
+__author__ = "etseng@pacb.com"
+
+log = logging.getLogger(__name__)
+
+
+def _sanity_check_args(args):
+    """Sanity check tofu arguments."""
+    # Check required arguments
+    if args.nfl_fa is None:
+        raise ValueError("--nfl_fa must be provided for tofu_wrap. Quit.")
+    if args.bas_fofn is None:
+        raise ValueError("--bas_fofn must be provided for polishing isoforms. Quit.")
+    if not args.quiver: # overwrite --quiver
+        logging.warning("--quiver must be turned on for tofu_wrap.")
+        args.quiver = True
+
+    # check gmap reference genome
+    if all(arg is None for arg in [args.gmap_db, args.gmap_name, args.gmap_ds]):
+        raise ValueError("GMAP reference Database is not set! Quit.")
+    # overwrite args.gmap_db, args.gmap_name if args.gmap_ds is not None
+    if args.gmap_ds is not None:
+        args.gmap_db, args.gmap_name = gmap_db_and_name_from_ds(args.gmap_ds)
+    # check gmap dir existence
+    if not op.exists(args.gmap_db):
+        raise IOError("GMAP DB location not valid: %s. Quit.", args.gmap_db)
+    if not op.exists(op.join(args.gmap_db, args.gmap_name)):
+        raise IOError("GMAP name not valid: %s. Quit.", args.gmap_name)
+
+    # check output file format
+    if not any(args.collapsed_filtered_fn.endswith(ext) for ext in
+               (".fa", ".fasta", ".fq", ".fastq")):
+        raise ValueError("Output file %s must be FASTA or FASTQ!" % args.collapsed_filtered_fn)
+
+
+def add_tofu_output_arguments(parser):
+    """Add tofu output arguments"""
+    out_group = parser.add_argument_group("Tofu output arguments")
+
+    helpstr = "Directory to store tofu output files (default: tofu_out)"
+    out_group.add_argument("-d", "--tofu_dir", "--outDir", type=str, dest="tofu_dir",
+                           default="tofu_out", help=helpstr)
+    helpstr = "Sample name. If not given, a random ID is generated"
+    out_group.add_argument("--sample_name", "--output_seqid_prefix", dest="sample_name",
+                           type=str, default=None, help=helpstr)
+
+    helpstr = "Output GFF file containing collapsed filtered isoform groups " + \
+              "(default: <output_prefix>.gff)"
+    out_group.add_argument("--gff", default=None, type=str, dest="gff_fn", help=helpstr)
+    helpstr = "Output group TXT file which associates collapsed filtered isoform groups " + \
+              "with member isoforms (default: <output_prefix>.group.txt)."
+    out_group.add_argument("--group", default=None, type=str, dest="group_fn", help=helpstr)
+    helpstr = "Output abundance TXT file counting supportive FL/nFL CCS reads of collapsed " + \
+              "filtered isoform groups (default: <output_prefix>.abundance.txt)"
+    out_group.add_argument("--abundance", default=None, type=str, dest="abundance_fn", help=helpstr)
+    helpstr = "Output read stat TXT file which associates CCS reads with collapsed isoform " + \
+              "groups (default: <output_prefix>.read_stat.txt)"
+    out_group.add_argument("--read_stat", default=None, type=str, dest="read_stat_fn", help=helpstr)
+    helpstr = "Output cluster summary JSON file (default: <tofu_dir>/combined/all.cluster_summary.json)"
+    out_group.add_argument("--summary", default=None, type=str, dest="summary_fn", help=helpstr)
+    helpstr = "Output cluster report CSV file (default: <tofu_dir>/combined/all.cluster_report.csv)."
+    out_group.add_argument("--report", default=None, type=str, dest="report_fn", help=helpstr)
+
+    return parser
+
+
+def get_parser():
+    """Returns arg parser."""
+    parser = argparse.ArgumentParser(prog='tofu_wrap')
+
+    helpstr = "Input full-length non-chimeric reads in FASTA or ContigSet format " + \
+              "(e.g., isoseq_flnc.fasta|contigset.xml)"
+    parser.add_argument("flnc_fa", type=str, help=helpstr)
+    helpstr = "Output collapsed filtered isoforms in FASTA/FASTQ format (e.g., tofu_out.fastq)"
+    parser.add_argument("collapsed_filtered_fn", type=str, help=helpstr)
+
+    parser = add_nfl_fa_argument(parser, positional=False, required=True)
+    parser = add_fofn_arguments(parser, ccs_fofn=True, bas_fofn=True, fasta_fofn=True)
+
+    # tofu output arguments
+    parser = add_tofu_output_arguments(parser)
+
+    parser = add_ice_arguments(parser) # Add Ice options, including --quiver
+    parser = add_sge_arguments(parser, blasr_nproc=True, quiver_nproc=True, gcon_nproc=True) # Sge
+    parser = add_ice_post_quiver_hq_lq_qv_arguments(parser) # IceQuiver HQ/LQ QV options.
+
+    parser = add_separate_flnc_arguments(parser) # separate_flnc options
+    parser = add_gmap_arguments(parser) # map to gmap reference options
+    parser = add_post_mapping_to_genome_arguments(parser) # post mapping to genome options
+
+    misc_group = parser.add_argument_group("Misc arguments")
+    misc_group.add_argument("--mem_debug", default=False, action="store_true",
+            help=argparse.SUPPRESS)
+    misc_group.add_argument("--version", action='version', version='%(prog)s ' + str(get_version()))
+    return parser
+
+
+class TofuFiles(CombinedFiles):
+    """All input/output files used by tofu_wrap."""
+    def __init__(self, tofu_dir):
+        self.tofu_dir = tofu_dir
+        super(TofuFiles, self).__init__(combined_dir=op.join(tofu_dir, "combined"))
+
+    @property
+    def fasta_fofn_files_dir(self):
+        """Return directory for storing fasta files converted from subreads.bax/bas/bam files."""
+        return op.join(self.tofu_dir, "fasta_fofn_files")
+
+    @property
+    def separate_flnc_pickle(self):
+        """A pickle file (e.g., separate_flnc.pickle) containing file paths to binned
+        FLNC reads. Usually generated by separate_flnc."""
+        return op.join(self.tofu_dir, "separate_flnc.pickle")
+
+    @property
+    def sorted_gmap_sam(self):
+        """Sorted GMAP sam file which contains alignments mapping HQ isoforms to GMAP reference."""
+        return op.join(self.tofu_dir, "sorted_gmap.sam")
+
+    @property
+    def tofu_final_fa(self):
+        """Return final output collapsed filtered isoforms in FASTA"""
+        return op.join(self.tofu_dir, "tofu_final.fasta")
+
+    @property
+    def tofu_final_fq(self):
+        """Return final output collapsed filtered isoforms in FASTQ"""
+        return op.join(self.tofu_dir, "tofu_final.fastq")
+
+
+def args_runner(args):
+    """args runner"""
+    # sanity check arguments
+    _sanity_check_args(args)
+
+    ice_opts = IceOptions(quiver=args.quiver, use_finer_qv=args.use_finer_qv,
+                          targeted_isoseq=args.targeted_isoseq,
+                          ece_penalty=args.ece_penalty, ece_min_len=args.ece_min_len,
+                          nfl_reads_per_split=args.nfl_reads_per_split)
+    sge_opts = SgeOptions(unique_id=args.unique_id, use_sge=args.use_sge,
+                          max_sge_jobs=args.max_sge_jobs, blasr_nproc=args.blasr_nproc,
+                          quiver_nproc=args.quiver_nproc, gcon_nproc=args.gcon_nproc,
+                          sge_env_name=args.sge_env_name, sge_queue=args.sge_queue)
+    ipq_opts = IceQuiverHQLQOptions(qv_trim_5=args.qv_trim_5, qv_trim_3=args.qv_trim_3,
+                                    hq_quiver_min_accuracy=args.hq_quiver_min_accuracy)
+
+    # FIXME: convert *.bas.h5|bax.h5|dataset.xml to fofn
+#    # (2) if fasta_fofn already is there, use it; otherwise make it first
+#    if args.quiver and args.fasta_fofn is None:
+#        # FIXME
+#        print >> sys.stderr, "Making fasta_fofn now"
+#        nfl_dir = op.abspath(op.join(args.root_dir, "fasta_fofn_files"))
+#        if not op.exists(nfl_dir):
+#            os.makedirs(nfl_dir)
+#        args.fasta_fofn = op.join(nfl_dir, 'input.fasta.fofn')
+#        print >> sys.stderr, "fasta_fofn", args.fasta_fofn
+#        print >> sys.stderr, "nfl_dir", nfl_dir
+#        #FIXME
+#        convert_fofn_to_fasta(fofn_filename=args.bas_fofn, out_filename=args.fasta_fofn,
+#                              fasta_out_dir=nfl_dir)
+#    else:
+#        if not op.exists(args.fasta_fofn):
+#            raise Exception, "fasta_fofn {0} does not exist!".format(args.fasta_fofn)
+#        for line in open(args.fasta_fofn):, "cluster_out")
+#            line = line.strip()
+#            if len(line) > 0 and not op.exists(line):
+#                raise Exception, "File {0} does not exists in {1}".format(line, args.fasta_fofn)
+
+    print "%s arguments are:\n%s\n" % (__file__, args)
+    logging.info("%s arguments are:\n%s\n", __file__, args)
+
+    # (1) separate flnc reads into bins
+    logging.info("Separating FLNC reads into bins.")
+    tofu_f = TofuFiles(tofu_dir=args.tofu_dir)
+    s = SeparateFLNCRunner(flnc_fa=args.flnc_fa, root_dir=args.tofu_dir,
+                           out_pickle=tofu_f.separate_flnc_pickle,
+                           bin_size_kb=args.bin_size_kb, bin_by_primer=args.bin_by_primer,
+                           bin_manual=args.bin_manual, max_base_limit_MB=args.max_base_limit_MB)
+    s.run()
+
+    flnc_files = SeparateFLNCBase.convert_pickle_to_sorted_flnc_files(tofu_f.separate_flnc_pickle)
+    print flnc_files
+
+    # (2) apply 'pbtranscript cluster' to each bin
+    # run ICE/Quiver (the whole thing), providing the fasta_fofn
+    logging.info("Running ICE/Polish on separated FLNC reads bins.")
+    split_dirs = []
+    for flnc_file in flnc_files:
+        split_dir = op.join(realpath(op.dirname(flnc_file)), "cluster_out")
+        mkdir(split_dir)
+        split_dirs.append(split_dir)
+        cur_out_cons = op.join(split_dir, "consensus_isoforms.fasta")
+
+        ipq_f = IceQuiverPostprocess(root_dir=split_dir, ipq_opts=ipq_opts)
+        if op.exists(ipq_f.quivered_good_fq):
+            logging.warning("HQ polished isoforms %s already exist. SKIP!", ipq_f.quivered_good_fq)
+            continue
+        else:
+            logging.info("Running ICE/Quiver on %s", split_dir)
+
+        obj = Cluster(root_dir=split_dir, flnc_fa=flnc_file,
+                      nfl_fa=args.nfl_fa,
+                      bas_fofn=args.bas_fofn,
+                      ccs_fofn=args.ccs_fofn,
+                      fasta_fofn=args.fasta_fofn,
+                      out_fa=cur_out_cons, sge_opts=sge_opts,
+                      ice_opts=ice_opts, ipq_opts=ipq_opts)
+
+        if args.mem_debug: # DEBUG
+            from memory_profiler import memory_usage
+            start_t = time.time()
+            mem_usage = memory_usage(obj.run, interval=60)
+            end_t = time.time()
+            with open('mem_debug.log', 'a') as f:
+                f.write("Running ICE/Quiver on {0} took {1} secs.\n".format(split_dir,
+                                                                            end_t-start_t))
+                f.write("Maximum memory usage: {0}\n".format(max(mem_usage)))
+                f.write("Memory usage: {0}\n".format(mem_usage))
+        else:
+            obj.run()
+
+    # (3) merge polished isoform cluster from all bins
+    logging.info("Merging isoforms from all bins to %s.", tofu_f.combined_dir)
+    c = CombineRunner(combined_dir=tofu_f.combined_dir,
+                      sample_name=get_sample_name(args.sample_name),
+                      split_dirs=split_dirs, ipq_opts=ipq_opts)
+    c.run()
+    if args.summary_fn is not None:
+        ln(tofu_f.all_cluster_summary_fn, args.summary_fn)
+    if args.report_fn is not None:
+        ln(tofu_f.all_cluster_report_fn, args.report_fn)
+
+    # (4) map HQ isoforms to GMAP reference genome
+    map_isoforms_and_sort(input_filename=tofu_f.all_hq_fq, sam_filename=tofu_f.sorted_gmap_sam,
+                          gmap_db_dir=args.gmap_db, gmap_db_name=args.gmap_name,
+                          gmap_nproc=args.gmap_nproc)
+
+    # (5) post mapping to genome analysis, including
+    #     * collapse polished HQ isoform clusters into groups
+    #     * count abundance of collapsed isoform groups
+    #     * filter collapsed isoforms based on abundance info
+    logging.info("Post mapping to genome analysis.")
+    out_isoforms = args.collapsed_filtered_fn
+    if any(out_isoforms.endswith(ext) for ext in (".fa", ".fasta")):
+        in_isoforms = tofu_f.all_hq_fa
+    elif any(out_isoforms.endswith(ext) for ext in (".fq", ".fastq")):
+        in_isoforms = tofu_f.all_hq_fq
+    else:
+        raise ValueError("Output file %s must be FASTA or FASTQ!" % out_isoforms)
+
+    post_mapping_to_genome_runner(
+        in_isoforms=in_isoforms, in_sam=tofu_f.sorted_gmap_sam,
+        in_pickle=tofu_f.hq_lq_prefix_dict_pickle, out_isoforms=args.collapsed_filtered_fn,
+        out_gff=args.gff_fn, out_abundance=args.abundance_fn,
+        out_group=args.group_fn, out_read_stat=args.read_stat_fn,
+        min_aln_coverage=args.min_aln_coverage, min_aln_identity=args.min_aln_identity,
+        min_flnc_coverage=args.min_flnc_coverage, max_fuzzy_junction=args.max_fuzzy_junction,
+        allow_extra_5exon=args.allow_extra_5exon, min_count=args.min_count)
+
+    return 0
+
+
+def main(argv=sys.argv[1:]):
+    """tofu main."""
+    return pacbio_args_runner(
+        argv=argv,
+        parser=get_parser(),
+        args_runner_func=args_runner,
+        alog=log,
+        setup_log_func=setup_log)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,8 @@ setup(
         'collapse_mapped_isoforms.py = pbtranscript.tasks.collapse_mapped_isoforms:main',
         'make_abundance.py = pbtranscript.tasks.make_abundance:main',
         'filter_collapsed_isoforms.py = pbtranscript.tasks.filter_collapsed_isoforms:main',
-        'post_mapping_to_genome.py = pbtranscript.tasks.post_mapping_to_genome:main'
+        'post_mapping_to_genome.py = pbtranscript.tasks.post_mapping_to_genome:main',
+        'tofu_wrap.py = pbtranscript.tofu_wrap:main'
         ]},
     package_dir={'pbtranscript': 'pbtranscript'},
     package_data={'pbtranscript':

--- a/tests/unit/test_CombineUtils.py
+++ b/tests/unit/test_CombineUtils.py
@@ -1,0 +1,53 @@
+"""Test classes defined within pbtranscript.CombineUtils."""
+
+import unittest
+import os.path as op
+
+from pbcore.io import FastaReader, FastqReader
+from pbtranscript.Utils import rmpath, mkdir
+from pbtranscript.ClusterOptions import IceQuiverHQLQOptions
+from pbtranscript.CombineUtils import CombineRunner
+from test_setpath import DATA_DIR, OUT_DIR, SIV_DATA_DIR
+
+
+class TEST_CombineUtils(unittest.TestCase):
+
+    """Test functions of pbtranscript.CombineUtils."""
+
+    def setUp(self):
+        """Define input and output file."""
+        pass
+
+    def test_runner(self):
+        """Test CombineRunner."""
+        ipq_opts = IceQuiverHQLQOptions(qv_trim_5=100, qv_trim_3=30)
+        d = op.join(SIV_DATA_DIR, "test_tool_contract_chunks")
+        split_dirs = [op.join(d, b, "cluster_out") for b in
+                      ("0to1kb_part0", "1to2kb_part0", "2to3kb_part0", "3to4kb_part0", "4to5kb_part0")]
+        print split_dirs
+        out_combined_dir = op.join(OUT_DIR, "test_CombineUtils", "combined_dir")
+        rmpath(out_combined_dir)
+        mkdir(out_combined_dir)
+        obj = CombineRunner(combined_dir=out_combined_dir,
+                            sample_name="mysample",
+                            split_dirs=split_dirs,
+                            ipq_opts=ipq_opts)
+        obj.run()
+
+        expected_out_fns = (obj.all_hq_fa, obj.all_hq_fq, obj.all_lq_fa, obj.all_lq_fq,
+                            obj.all_consensus_isoforms_fa,
+                            obj.all_cluster_report_fn, obj.all_cluster_summary_fn)
+        self.assertTrue(all([op.exists(f) for f in expected_out_fns]))
+
+        expected_hq_isoforms = ['i1_HQ_mysample|c0/f2p16/1826', 'i2_HQ_mysample|c2/f9p14/2470',
+                                'i2_HQ_mysample|c5/f7p19/2472', 'i2_HQ_mysample|c10/f8p16/2457',
+                                'i2_HQ_mysample|c98/f2p10/2081', 'i2_HQ_mysample|c108/f23p28/2471']
+        self.assertEqual([r.name.split(' ')[0] for r in FastaReader(obj.all_hq_fa)], expected_hq_isoforms)
+        self.assertEqual([r.name.split(' ')[0] for r in FastqReader(obj.all_hq_fq)], expected_hq_isoforms)
+
+        expected_lq_isoforms_num = 73
+        self.assertEqual(len([r for r in FastaReader(obj.all_lq_fa)]), expected_lq_isoforms_num)
+
+        expected_consensus_isoforms_num = 79
+        self.assertEqual(len([r for r in FastaReader(obj.all_consensus_isoforms_fa)]), expected_consensus_isoforms_num)
+


### PR DESCRIPTION
tofu_wrap.py allows users to run the whole IsoSeq Cluster with Reference Genome pipeline starting from Full-length-non-chimeric (FLNC) reads. It performs the following subtasks:

(1) separate FLNC reads into bins
(2) Apply `pbtranscript cluster` on each FLNC bin and polish consensus isoforms using Arrow (Quiver)
(3) merge results from all bins
(4) map HQ polished consensus isoforms to reference genome using GMAP
(5) collapsed redundant HQ isoforms into groups based on mapping annotations; compute abundance info (supportive FLNC/nFL reads per collapsed isoform group); and filter collapsed isoform groups based on abundance info.