### PR TITLE
Expose customer primer in pbtranscript.tasks.classify tool contract

### DIFF
--- a/pbtranscript/PBTranscriptOptions.py
+++ b/pbtranscript/PBTranscriptOptions.py
@@ -32,6 +32,9 @@ class BaseConstants(object):
     MIN_SCORE_DEFAULT = 10
     IGNORE_POLYA_ID = "pbtranscript.task_options.ignore_polya"
     IGNORE_POLYA_DEFAULT = False
+    PRIMER_SEQUENCES_ID = "pbtranscript.task_options.primer_sequences"
+    PRIMER_SEQUENCES_DEFAULT = ""
+
     HQ_QUIVER_MIN_ACCURACY_ID = "pbtranscript.task_options.hq_quiver_min_accuracy"
     HQ_QUIVER_MIN_ACCURACY_DEFAULT = 0.99
     HQ_QUIVER_MIN_ACCURACY_DESC = "Minimum allowed quiver accuracy to classify an isoform " + \
@@ -106,6 +109,11 @@ def add_classify_arguments(parser):
                            dest="primerFN",
                            default=None,
                            help="Primer FASTA file (default: primers.fasta)")
+
+    tcp.add_str(BaseConstants.PRIMER_SEQUENCES_ID, "customer_primers",
+                default=BaseConstants.PRIMER_SEQUENCES_DEFAULT,
+                name="Customer primer sequences",
+                description="Customer primer sequences.")
 
     hmm_group.add_argument("--cpus",
                            default=8,

--- a/pbtranscript/counting/Count.py
+++ b/pbtranscript/counting/Count.py
@@ -107,7 +107,7 @@ class CountRunner(object):
             fl_fn = IceFiles(prog_name="Count", root_dir=cluster_out_d, no_log_f=True).final_pickle_fn
             if not op.exists(fl_fn):
                 raise IOError("FL pickle %s of sample prefix %s does not exist." %
-                              fl_fn, sample_prefix)
+                              (fl_fn, sample_prefix))
             ret.append((sample_prefix, fl_fn))
         return ret
 
@@ -120,7 +120,7 @@ class CountRunner(object):
             nfl_fn = IceFiles(prog_name="Count", root_dir=cluster_out_d, no_log_f=True).nfl_all_pickle_fn
             if not op.exists(nfl_fn):
                 raise IOError("NFL pickle %s of sample prefix %s does not exist." %
-                              nfl_fn, sample_prefix)
+                              (nfl_fn, sample_prefix))
             ret.append((sample_prefix, nfl_fn))
         return ret
 

--- a/pbtranscript/tasks/classify.py
+++ b/pbtranscript/tasks/classify.py
@@ -11,9 +11,12 @@ import logging
 import os.path as op
 import sys
 
+from pbcore.io import FastaRecord, FastaWriter
+
 from pbcommand.cli.core import pbparser_runner
 from pbcommand.utils import setup_log
 
+from pbtranscript.Utils import mkdir
 from pbtranscript.PBTranscriptRunner import PBTranscript
 from pbtranscript.PBTranscriptOptions import (BaseConstants,
                                               get_base_contract_parser,
@@ -22,23 +25,60 @@ from pbtranscript.PBTranscriptOptions import (BaseConstants,
 
 log = logging.getLogger(__name__)
 
+
+def parse_primer_sequences(primers_str):
+    """
+    Return a list of primer FastaRecords if primers_str only contains
+    valid primers. Otherwise raise a ValueError.
+    """
+    if isinstance(primers_str, str) or isinstance(primers_str, unicode):
+        primer_fasta_records = []
+        primers_str = str(primers_str)
+        if '>' not in primers_str:
+            raise ValueError("Invalid primer header, could not find leading '>'.")
+        for str_index, primer_str in enumerate(primers_str.split('>')[1:]):
+            lines = [line.strip().translate(None, '\'\" ') for line in primer_str.split('\n')]
+            lines = [line for line in lines if len(line) > 0] # remove empty lines
+            if len(lines) < 2:
+                raise ValueError("Primer %s must have a sequence." % lines[0])
+            primer_name = lines[0]
+            primer_sequence = ''.join(lines[1:])
+            primer_index = int(str_index / 2)
+            primer_strand = 'F' if str_index % 2 == 0 else 'R'
+            expected_primer_name = "{s}{i}".format(s=primer_strand, i=primer_index)
+            if primer_name != expected_primer_name:
+                raise ValueError("Primers should be placed in order F0, R0, F1, R1...")
+            for base in primer_sequence:
+                if base.upper() not in ('A', 'T', 'G', 'C'):
+                    raise ValueError("Primer sequence %s must only contain ATGC" % primer_sequence)
+            primer_fasta_records.append(FastaRecord(header=primer_name, sequence=primer_sequence))
+
+        return primer_fasta_records
+
+    raise ValueError("Input primers_str %s must be either str or unicode" % type(primers_str))
+
+
 class Constants(BaseConstants):
+    """Define constants used in pbtranscript.tasks.classify"""
     TOOL_ID = "pbtranscript.tasks.classify"
-    DRIVER_EXE = "python -m pbtranscript.tasks.classify --resolved-tool-contract"
+    DRIVER_EXE = "python -m %s --resolved-tool-contract" % TOOL_ID
     PARSER_DESC = __doc__
 
 
 def get_contract_parser():
+    """Get PbParser for classify."""
     p = get_base_contract_parser(Constants, default_level="DEBUG")
     add_classify_arguments(p)
     return p
 
 
 def args_runner(args):
+    """Call Args runner"""
     return PBTranscript(args, subCommand="classify").start()
 
 
 def resolved_tool_contract_to_args(resolved_tool_contract):
+    """Convert resolved tool contract to args."""
     rtc = resolved_tool_contract
     args = [
         "--verbose",
@@ -56,6 +96,25 @@ def resolved_tool_contract_to_args(resolved_tool_contract):
     ]
     if rtc.task.options[Constants.IGNORE_POLYA_ID]:
         args.append("--ignore_polyA")
+
+    primers_str_obj = rtc.task.options[Constants.PRIMER_SEQUENCES_ID]
+    primers_str = str(primers_str_obj).strip().translate(None, '\'\" ')
+    if primers_str_obj is not None and primers_str not in ('None', ''):
+        logging.info("Detected customer primer: %s", primers_str)
+        # Save primer sequences to a fasta file under output dir
+        primer_fasta_records = parse_primer_sequences(primers_str=primers_str)
+        d = op.dirname(resolved_tool_contract.task.output_files[2])
+        mkdir(d)
+        primer_fn = op.join(d, "customer_primers.fasta")
+        with FastaWriter(primer_fn) as writer:
+            for record in primer_fasta_records:
+                writer.writeRecord(record)
+        logging.info("Customer primer sequences written to file %s", primer_fn)
+        args.append("-p")
+        args.append("%s" % primer_fn)
+    else:
+        logging.info("No customer primer detected.")
+
     return get_argument_parser().parse_args(args)
 
 

--- a/tests/cram/counting.t
+++ b/tests/cram/counting.t
@@ -19,9 +19,9 @@
   $ cat $O_READ_STAT |wc -l
   10416
 
-  $ head -2 $O_READ_STAT 
-  id	length	is_fl	stat	pbid
-  m54006_160328_233933/17957574/30_1837_CCS	1807	Y	unique	PB.5.4
+$ head -2 $O_READ_STAT 
+id	length	is_fl	stat	pbid
+m54006_160328_233933/17957574/30_1837_CCS	1807	Y	unique	PB.5.4
 
   $ cat $O_ABUNDANCE | grep -v ^# | wc -l
   39


### PR DESCRIPTION
Expose customer primers in pbtranscript.tasks.classify tool contract

Users can now specify customer primers in SMRTLink GUI. An example of customer primers are:
```
>F0
aagcagtggtatcaacgcagagtacAGCTCCGGCACCAACAGCA
>R0
GCATCGACATGGTAGACTCGgtactctgcgttgataccactgctt
>F1
aagcagtggtatcaacgcagagtacGTTGCCCGCCATGGCTGAG
>R1
CTGGTGCACTGAAGAGCCACgtactctgcgttgataccactgctt
```
Also include two commits which fixed counting log info and counting.t cram test.