### PR TITLE
Added a rescue script picking_up_ice.py and a cram test

### DIFF
--- a/pbtranscript/ClusterOptions.py
+++ b/pbtranscript/ClusterOptions.py
@@ -175,8 +175,12 @@ class IceOptions(object):
     def _write_config(self, fasta_filename):
         """Write daligner sensitive config to fasta_filename.sensitive.config."""
         lens = [len(r.sequence) for r in ContigSetReaderWrapper(fasta_filename)]
-        self.low_cDNA_size  = int(np.percentile(lens, 10))
-        self.high_cDNA_size = int(np.percentile(lens, 90))
+        self.low_cDNA_size, self.high_cDNA_size = 0, 0
+        if len(lens) == 1:
+            self.low_cDNA_size, self.high_cDNA_size = lens[0], lens[0]
+        if len(lens) >= 2:
+            self.low_cDNA_size  = int(np.percentile(lens, 10))
+            self.high_cDNA_size = int(np.percentile(lens, 90))
 
         try:
             with open(fasta_filename+'.sensitive.config', 'w') as f:

--- a/pbtranscript/PBTranscriptOptions.py
+++ b/pbtranscript/PBTranscriptOptions.py
@@ -627,11 +627,11 @@ def add_cluster_arguments(parser):
                                     tool_contract_parser=tool_contract_parser)
 
     helpstr = "Directory to store temporary and output cluster files." + \
-        "(default: output/)"
+        "(default: cluster_out/)"
     arg_parser.add_argument("-d", "--outDir",
                             type=str,
                             dest="root_dir",
-                            default="output",
+                            default="cluster_out",
                             help=helpstr)
 
     arg_parser = add_tmp_dir_argument(arg_parser)

--- a/pbtranscript/PBTranscriptOptions.py
+++ b/pbtranscript/PBTranscriptOptions.py
@@ -268,6 +268,18 @@ def add_ice_arguments(arg_parser, tc_parser=None):
                            action="store",
                            default=100,
                            help=argparse.SUPPRESS)
+    # number of flnc reads per split
+    ice_group.add_argument("--flnc_reads_per_split",
+                           type=int,
+                           action="store",
+                           default=20000,
+                           help=argparse.SUPPRESS)
+    # number of nfl reads per split
+    ice_group.add_argument("--nfl_reads_per_split",
+                           type=int,
+                           action="store",
+                           default=30000,
+                           help=argparse.SUPPRESS)
 
     desc = "Use finer classes of QV information from CCS input instead of "+\
            "a single QV from FASTQ.  This option is slower and consumes "+\

--- a/pbtranscript/PBTranscriptRunner.py
+++ b/pbtranscript/PBTranscriptRunner.py
@@ -122,6 +122,8 @@ class PBTranscript(PBMultiToolRunner):
                 ice_opts = IceOptions(quiver=self.args.quiver,
                                       use_finer_qv=self.args.use_finer_qv,
                                       targeted_isoseq=self.args.targeted_isoseq,
+                                      flnc_reads_per_split=self.args.flnc_reads_per_split,
+                                      nfl_reads_per_split=self.args.nfl_reads_per_split,
                                       num_clusters_per_bin=self.args.num_clusters_per_bin)
                 sge_opts = SgeOptions(unique_id=self.args.unique_id,
                                       use_sge=self.args.use_sge,

--- a/pbtranscript/ice/IceIterative.py
+++ b/pbtranscript/ice/IceIterative.py
@@ -165,6 +165,8 @@ class IceIterative(IceFiles):
         else:
             if self.use_finer_qv: # use multi-QVs from ccs.h5
                 pass # no need to convert FASTA to FASTQ
+            elif ccs_fofn is None:
+                pass # get prob QVs from a fixed model
             else: # use a single Qv from FASTQ, convert FASTA to FASTQ first
                 self.fastq_filename = fafn2fqfn(self.fasta_filename)
                 self.add_log("Converting input {fa} + {ccs} --> {fq}.",

--- a/pbtranscript/ice/IceUtils.py
+++ b/pbtranscript/ice/IceUtils.py
@@ -805,7 +805,7 @@ def blasr_for_quiver(query_fn, ref_fasta, out_fn, bam=False,
 
 def num_reads_in_fasta(in_fa):
     """Return the number of reads in the in_fa fasta file."""
-    if (not in_fa.endswith(".fa")) or (not in_fa.endswith(".fasta")):
+    if (not in_fa.endswith(".fa")) and (not in_fa.endswith(".fasta")):
         # if not a fasta file, must be a contigset xml
         if not in_fa.endswith(".xml"):
             raise IOError("%s must be a FASTA or ContigSet file." % in_fa)

--- a/pbtranscript/io/DazzIDHandler.py
+++ b/pbtranscript/io/DazzIDHandler.py
@@ -184,14 +184,13 @@ class DazzIDHandler(object):
         if not op.exists(self.db_filename):
             self.make_db()
 
-        with open(self.db_filename) as f:
-            f.readline()
-            f.readline()
-            x = f.readline().strip()
-            if not x.startswith('blocks ='):
-                raise ValueError("Could not get number of blocks in DAZZ DB %s"
-                                 % self.db_filename)
-        return int(x.split('=')[1])
+        bs = [line.strip() for line in open(self.db_filename, 'r')
+              if line.strip().startswith("blocks =")]
+        if len(bs) == 1:
+            return int(bs[0].split('=')[1])
+        raise ValueError("Could not get number of blocks in DAZZ DB %s"
+                         % self.db_filename)
+
 
     def __getitem__(self, key):
         """

--- a/pbtranscript/picking_up_ice.py
+++ b/pbtranscript/picking_up_ice.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+import os.path as op
+import sys
+import logging
+from argparse import ArgumentParser
+from cPickle import load, dump
+from pbcore.io.FastaIO import FastaReader, FastaWriter
+from pbtranscript.ice.ProbModel import ProbFromModel, ProbFromFastq
+import pbtranscript.ice.IceIterative as ice
+from pbtranscript.ice.IceUtils import ice_fa2fq, realpath
+from pbtranscript.PBTranscriptOptions import add_fofn_arguments
+
+FORMATTER = op.basename(__file__) + ':%(levelname)s:'+'%(message)s'
+logging.basicConfig(level=logging.DEBUG, format=FORMATTER)
+log = logging.getLogger(__name__)
+
+
+__author__ = "etseng@pacificbiosciences.com"
+
+
+def add_picking_up_ice_arguments(parser):
+    """Add arguments for picking up ice."""
+    helpstr = "Last successful pickle (e.g., clusterOut/output/input.split_001.fa.pickle)"
+    parser.add_argument("pickle_filename", help=helpstr)
+
+    helpstr = "root dir (default: cluster_out/)"
+    parser.add_argument("--root_dir", default="cluster_out", help=helpstr)
+
+    # FIXME, use ccs.xml instead
+    parser = add_fofn_arguments(parser, ccs_fofn=True)
+
+    helpstr = "Input full-length non-chimeric reads in FASTA or ContigSet format, " + \
+              "used for clustering consensus isoforms, e.g., isoseq_flnc.fasta"
+    parser.add_argument("--flnc", "--flnc_fa", default="isoseq_flnc.fasta", help=helpstr)
+
+    helpstr = "Comma-separated additional fasta files to add."
+    parser.add_argument("--fasta_files_to_add", default=None, help=helpstr)
+    return parser
+
+
+def current_fasta(root_dir):
+    """Return filename of root_dir/current.fasta, which is used in
+    the `current` ICE iteration."""
+    return realpath(op.join(root_dir, "current.fasta"))
+
+
+def current_fastq(root_dir):
+    """Return filename of root_dir/current.fastq, which is used in
+    the `current` ICE iteration."""
+    return realpath(op.join(root_dir, "current.fastq"))
+
+
+def ensure_pickle_goodness(pickle_filename, root_dir, fasta_files_to_add=None):
+    """
+    Old versions of IceIterative.write_pickle is missing some key/values.
+    Add if needed.
+    Return a good pickle object, and the pickle's filename
+    """
+    a = load(open(pickle_filename))
+    if realpath(a['fasta_filename']) != current_fasta(root_dir):
+        raise ValueError("The pickle file %s indicates that " % pickle_filename +
+                         "current.fasta is not being used. ICE likely did not " +
+                         "finish to a point that could be picked up.")
+
+    a['newids'] = check_n_fix_newids(a)
+
+    if fasta_files_to_add is not None:
+        for f in fasta_files_to_add.split(','):
+            if not op.exists(f):
+                raise IOError("%s is not a valid fasta file to add!" % f)
+            if f in a['fasta_filenames_to_add']:
+                log.warning("%s is already in to-add list. Ignore.", f)
+            a['fasta_filenames_to_add'].append(f)
+    if 'root_dir' not in a:
+        log.warning("Pickle %s missing some key-values. Fixing it.", pickle_filename)
+        a['root_dir'] = root_dir
+        a['all_fasta_filename'] = a['all_fasta_fiilename']
+        a['qv_prob_threshold'] = 0.03
+        fixed_pickle_filename = pickle_filename + ".fixed"
+        with open(fixed_pickle_filename, 'w') as f:
+            dump(a, f)
+        log.info("Fixed pickle written to %s", fixed_pickle_filename)
+        return a, fixed_pickle_filename
+    else:
+        # newid might have been fixed, STILL output pickle writing anyway
+        with open(pickle_filename, 'w') as f:
+            dump(a, f)
+        return a, pickle_filename
+
+
+def check_n_fix_newids(icec_obj):
+    """
+    Check and fix newids in icec_obj['newids'], return valid newids
+    """
+    newids = icec_obj['newids']
+
+    if len(newids) == 0:
+        log.info("newids is empty (probably a finalized run). set it.")
+        for k, v in icec_obj['d'].iteritems():
+            if len(v) != 1:
+                newids.add(k)
+        log.info("added %s seqs to newids", len(newids))
+    return newids
+
+
+def make_current_fasta(icec_obj, flnc_filename, root_dir):
+    """
+    current fasta will consists of all ids
+
+    however --- if this was a already finished run and we are adding more input,
+        then newids is empty, in this case we set newids = everything that
+        has no affiliation or more than one affiliated cluster in d
+    """
+    with FastaWriter(current_fasta(root_dir)) as f:
+        for r in FastaReader(flnc_filename):
+            f.writeRecord(r)
+
+
+def pickup_icec_job(pickle_filename, ccs_fofn, flnc_filename, fasta_files_to_add, root_dir):
+    """
+    Reconstruct an ICE object from a pickle file and restart this ICE job.
+    """
+    log.info("Reading ICE pickle %s ....", pickle_filename)
+    icec_obj, icec_pickle_filename = ensure_pickle_goodness(
+        pickle_filename=pickle_filename, root_dir=root_dir,
+        fasta_files_to_add=fasta_files_to_add)
+
+    c_fa = current_fasta(root_dir)
+    c_fq = current_fastq(root_dir)
+    log.info("Making current.fasta %s for ICE ....", c_fa)
+    make_current_fasta(icec_obj=icec_obj, flnc_filename=flnc_filename, root_dir=root_dir)
+
+    log.info("Loading prob QV information....")
+    probqv = None
+    if ccs_fofn is None:
+        logging.info("Loading probability from model (0.01,0.07,0.06)")
+        probqv = ProbFromModel(.01, .07, .06)
+    else:
+        #if use_finer_qv:
+        #    probqv = ProbFromQV(input_fofn=ccs_fofn, fasta_filename=input_fasta)
+        #    logging.info("Loading prob QVs from %s + %s took %s secs",
+        #                 ccs_fofn, input_fasta, time.time()-start_t)
+        logging.info("Converting %s to %s", c_fa, c_fq)
+        ice_fa2fq(c_fa, ccs_fofn, c_fq)
+
+        logging.info("Loading prob QVs from %s", c_fq)
+        probqv = ProbFromFastq(c_fq)
+
+    log.info("Starting ICE from pickle %s....", icec_pickle_filename)
+    icec = ice.IceIterative.from_pickle(icec_pickle_filename, probqv)
+
+    # first must RE-RUN gcon to get all the proper refs
+    icec.changes = set()
+    icec.refs = {}
+    icec.ccs_fofn = ccs_fofn
+    icec.all_fasta_filename = flnc_filename
+    todo = icec.uc.keys()
+    log.info("Re-run gcon for proper refs....")
+    icec.run_gcon_parallel(todo)
+
+    log.info("Re-calculating cluster prob, just to be safe....")
+    icec.calc_cluster_prob(True)
+
+    log.info("Sanity checking uc_refs now....")
+    icec.sanity_check_uc_refs()
+
+    log.info("Ensuring prob QV of new ids are consistent....")
+    icec.ensure_probQV_newid_consistency()
+
+    log.info("Sanity check done. Resuming ICE job.")
+    icec.run()
+
+
+def main():
+    """Main function to pick up ICE"""
+    parser = add_picking_up_ice_arguments(parser=ArgumentParser())
+    args = parser.parse_args()
+    pickup_icec_job(pickle_filename=args.pickle_filename,
+                    ccs_fofn=args.ccs_fofn,
+                    flnc_filename=args.flnc,
+                    fasta_files_to_add=args.fasta_files_to_add,
+                    root_dir=args.root_dir)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pbtranscript/tofu_wrap.py
+++ b/pbtranscript/tofu_wrap.py
@@ -208,6 +208,7 @@ def args_runner(args):
     ice_opts = IceOptions(quiver=args.quiver, use_finer_qv=args.use_finer_qv,
                           targeted_isoseq=args.targeted_isoseq,
                           ece_penalty=args.ece_penalty, ece_min_len=args.ece_min_len,
+                          flnc_reads_per_split=args.flnc_reads_per_split,
                           nfl_reads_per_split=args.nfl_reads_per_split)
     sge_opts = SgeOptions(unique_id=args.unique_id, use_sge=args.use_sge,
                           max_sge_jobs=args.max_sge_jobs, blasr_nproc=args.blasr_nproc,

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
              'pbtranscript/ice_quiver.py',
              'pbtranscript/ice_fa2fq.py',
              'pbtranscript/ice_daligner.py',
-             'pbtranscript/ice_combine_cluster_bins.py'
+             'pbtranscript/ice_combine_cluster_bins.py',
             ],
     entry_points={'console_scripts': [
         'pbtranscript = pbtranscript.PBTranscriptRunner:main',
@@ -105,6 +105,7 @@ setup(
         'ice_polish.py = pbtranscript.Polish:main',
         'ice_make_input_fasta_fofn.py = pbtranscript.ice.make_input_fasta_fofn:main',
         'separate_flnc.py = pbtranscript.tasks.separate_flnc:main',
+        'picking_up_ice.py = pbtranscript.picking_up_ice:main',
         'map_isoforms_to_genome.py = pbtranscript.tasks.map_isoforms_to_genome:main',
         'collapse_mapped_isoforms.py = pbtranscript.tasks.collapse_mapped_isoforms:main',
         'make_abundance.py = pbtranscript.tasks.make_abundance:main',

--- a/tests/cram/cluster_bam_in.t
+++ b/tests/cram/cluster_bam_in.t
@@ -22,10 +22,10 @@
 
 # Test pbtranscript cluster, bam input, no finer qvs, no quiver.
   $ rm -rf $OFA $OD && mkdir -p $OD
-  $ pbtranscript cluster $FLNC $OFA -d $OD --bas_fofn $BAS --ccs_fofn $CCS  --quiver --nfl $NFL
+  $ pbtranscript cluster $FLNC $OFA -d $OD --bas_fofn $BAS --ccs_fofn $CCS  --quiver --nfl_fa $NFL
   $ ls $OFA > /dev/null
 
 # Test pbtranscript cluster, bam input, using finer qvs, quiver.
   $ rm -rf $OFA $OD && mkdir -p $OD
-  $ pbtranscript cluster $FLNC $OFA -d $OD --bas_fofn $BAS --ccs_fofn $CCS  --use_finer_qv --quiver --nfl $NFL
+  $ pbtranscript cluster $FLNC $OFA -d $OD --bas_fofn $BAS --ccs_fofn $CCS  --use_finer_qv --quiver --nfl_fa $NFL
   $ ls $OFA > /dev/null

--- a/tests/cram/cluster_dataset_input.t
+++ b/tests/cram/cluster_dataset_input.t
@@ -17,5 +17,5 @@
 
 # Test pbtranscript cluster, dataset input, using finer qvs, quiver.
   $ rm -rf $OFA $OD && mkdir -p $OD
-  $ pbtranscript cluster $FLNC $OFA -d $OD --bas_fofn $BAS --ccs_fofn $CCS  --use_finer_qv --quiver --nfl $NFL
+  $ pbtranscript cluster $FLNC $OFA -d $OD --bas_fofn $BAS --ccs_fofn $CCS  --use_finer_qv --quiver --nfl_fa $NFL
   $ wc $OFA > /dev/null

--- a/tests/cram/test_ice_entries/picking_up_ice.t
+++ b/tests/cram/test_ice_entries/picking_up_ice.t
@@ -1,0 +1,31 @@
+Test picking_up_ice.py
+
+How to create testing dataset which is a halted `pbtranscript cluster` job?
+Call the cmd below and then Ctrl + c to halt the job.
+$ pbtranscript --verbose cluster isoseq_flnc.fasta out.fasta --bas_fofn=$subreads -d=output --flnc_reads_per_split=3
+
+How to test picking_up_ice.py?
+$ picking_up_ice.py output/output/input.split_001.fasta.pickle --root_dir=output
+
+
+Set up
+  $ . $TESTDIR/setup.sh
+
+  $ subreads=/pbi/dept/secondary/siv/testdata/SA3-Sequel/rc0/315/3150353/r54086_20160831_010819/4_D01_tiny/tiny_flea_isoseq.subreadset.xml
+  $ flnc=$SIVDATDIR/test_ice_entries/test_picking_up_ice/isoseq_flnc.fasta
+  $ out_dir=$OUTDIR/test_picking_up_ice
+
+  $ rm -rf $out_dir && mkdir -p $out_dir
+  $ pbtranscript --verbose cluster $flnc $out_dir/out.fasta --bas_fofn=$subreads -d=$out_dir --flnc_reads_per_split=4 1>/dev/null 2>/dev/null && echo $?
+  0
+
+Delete intermediate ICE output pickle file for split_002
+  $ rm $out_dir/output/input.split_002.fasta.consensus.fasta  $out_dir/output/input.split_002.fasta.pickle && echo $?
+  0
+ 
+Restart from ICE pickle file for split_001
+  $ picking_up_ice.py $out_dir/output/input.split_001.fasta.pickle --root_dir=$out_dir --flnc=$flnc 1>/dev/null 2>/dev/null && echo $?
+  0
+
+  $ ls $out_dir/output/input.split_002.fasta.consensus.fasta  $out_dir/output/input.split_002.fasta.pickle 1>/dev/null && echo $?
+  0

--- a/tests/regression/run_isoseq_bam_in.sh
+++ b/tests/regression/run_isoseq_bam_in.sh
@@ -15,4 +15,4 @@ OUTFA=$BAM_OUTDIR/cluster_out.fasta
 
 echo Running pbtranscript cluster with --quiver
 rm -rf $BAM_OUTDIR $OUTFA
-pbtranscript cluster $FLNC $OUTFA -d $BAM_OUTDIR --bas_fofn $BAM --ccs_fofn $CCS --quiver --nfl $NFL --use_finer_qv --blasr_nproc 8 --quiver_nproc 8 || (echo pbtranscript FAILED WITH CODE $? && exit 1)
+pbtranscript cluster $FLNC $OUTFA -d $BAM_OUTDIR --bas_fofn $BAM --ccs_fofn $CCS --quiver --nfl_fa $NFL --use_finer_qv --blasr_nproc 8 --quiver_nproc 8 || (echo pbtranscript FAILED WITH CODE $? && exit 1)

--- a/tests/unit/test_IceUtils.py
+++ b/tests/unit/test_IceUtils.py
@@ -243,8 +243,14 @@ class Test_ICEUtils(unittest.TestCase):
                                         prob_model_from="fastq")
 
     @unittest.skipUnless(backticks('qstat')[1] == 0, "sge disabled")
-    def tes_daligner_against_ref_use_sge(self):
+    def test_daligner_against_ref_use_sge(self):
         """Test daligner_against_ref() using fake prob model on sge."""
         test_name = "test_daligner_against_ref_use_sge"
-        self._test_daligner_against_ref(test_name=test_name, use_sge=True, sge_opts=SgeOptions())
+        self._test_daligner_against_ref(test_name=test_name, use_sge=True, sge_opts=SgeOptions(100))
 
+    def test_num_reads_in_fasta(self):
+        """Test num_reads_in_fasta"""
+        in_fa = op.join(self.sivDataDir, "flnc.fasta")
+        in_xml = op.join(self.sivDataDir, "test_tool_contract_chunks/isoseq_flnc.contigset.xml")
+        self.assertEqual(226, num_reads_in_fasta(in_fa))
+        self.assertEqual(161, num_reads_in_fasta(in_xml))


### PR DESCRIPTION
Added a rescue script picking_up_ice.py and a cram test

* picking_up_ice.py picks up a halted/failed ICE job and resume from the latest checkpoints.

Added a few hidden options for tests
Fixed several boundary case issues when handle empty or small fasta files.
Changed `pbtranscript cluster`'s default root dir from output to cluster_out so that it's consistent with dirnames in pbsmrtpipe isoseq jobs.