### PR TITLE
Support call to samtools version 1.3.1

### DIFF
--- a/pbtranscript/Utils.py
+++ b/pbtranscript/Utils.py
@@ -487,3 +487,37 @@ def get_sample_name(input_sample_name):
         return str("sample"+binascii.b2a_hex(os.urandom(3)))
     else:
         return input_sample_name
+
+
+def get_samtools_version():
+    """
+    Return samtools version string.
+    If samtools supports '--version', return its version.
+    Otherwise, return '0.1.19' which is the one used in SA2.x, SA3.0, SA3.1 and SA3.2.
+    """
+    default_sam_version = "0.1.19"
+    cmd = 'samtools --version'
+    _out, _code, _msg = backticks(cmd)
+    try:
+        if "samtools" in _out[0]:
+            return str(_out[0][8:]).strip()
+    except Exception:
+        # samtools used in SA2.x and SA3.1, SA3.2 is
+        # version 0.1.19, which does not support --version
+        # samtools used in SA3.3 or up is 1.3.1
+        return default_sam_version
+
+
+def use_samtools_v_1_3_1():
+    """Return True if samtools major version is >= 1.3.1"""
+    try:
+        versions = get_samtools_version().split('.')
+        major, minor, last = 0, 0, 0
+        major = int(versions[0])
+        if len(versions) >= 2:
+            minor = int(versions[1])
+            if len(versions) >= 3:
+                last = int(versions[2])
+        return major >= 2 or (major == 1 and minor > 3) or (major == 1 and minor == 3 and last >= 1)
+    except:
+        return False

--- a/tests/cram/test_ice_entries/ice_quiver.t
+++ b/tests/cram/test_ice_entries/ice_quiver.t
@@ -11,22 +11,27 @@ Set up
 
   $ rm -rf $out_dir && mkdir -p $out_dir
   $ cp -r $src_tasks_dir/pbtranscript.tasks.separate_flnc-0/3to4kb_part0/cluster_out/* $out_dir/
-  $ ice_quiver.py --verbose all $out_dir --bas_fofn=$subreads 1>/dev/null 2>/dev/null & echo $?
+  $ rm -rf $out_dir/all_quivered_hq.100_30_0.99.fasta $out_dir/all_quivered_hq.100_30_0.99.fastq $out_dir/all_quivered_lq.fasta $out_dir/all_quivered_lq.fastq 2>&1 > /dev/null
+
+  $ ice_quiver.py --verbose all $out_dir --bas_fofn=$subreads 1>/dev/null 2>/dev/null && echo $?
   0
+
   $ ls $out_dir/all_quivered_hq.100_30_0.99.fasta $out_dir/all_quivered_hq.100_30_0.99.fastq $out_dir/all_quivered_lq.fasta $out_dir/all_quivered_lq.fastq 2>&1 > /dev/null && echo $?
   0
 
   $ rm -rf $out_dir && mkdir -p $out_dir
   $ cp -r $src_tasks_dir/pbtranscript.tasks.separate_flnc-0/3to4kb_part0/cluster_out/* $out_dir/
-  $ ice_quiver.py --verbose i   $out_dir 3 0 --bas_fofn=$subreads 1>/dev/null 2>/dev/null & echo $?
+  $ rm -rf $out_dir/all_quivered_hq.100_30_0.99.fasta $out_dir/all_quivered_hq.100_30_0.99.fastq $out_dir/all_quivered_lq.fasta $out_dir/all_quivered_lq.fastq 2>&1 > /dev/null
+
+  $ ice_quiver.py --verbose i   $out_dir 3 0 --bas_fofn=$subreads 1>/dev/null 2>/dev/null && echo $?
   0
-  $ ice_quiver.py --verbose i   $out_dir 3 1 --bas_fofn=$subreads 1>/dev/null 2>/dev/null & echo $?
+  $ ice_quiver.py --verbose i   $out_dir 3 1 --bas_fofn=$subreads 1>/dev/null 2>/dev/null && echo $?
   0
-  $ ice_quiver.py --verbose i   $out_dir 3 2 --bas_fofn=$subreads 1>/dev/null 2>/dev/null & echo $?
+  $ ice_quiver.py --verbose i   $out_dir 3 2 --bas_fofn=$subreads 1>/dev/null 2>/dev/null && echo $?
   0
-  $ ice_quiver.py --verbose merge   $out_dir 3 1>/dev/null 2>/dev/null & echo $?
+  $ ice_quiver.py --verbose merge   $out_dir 3 1>/dev/null 2>/dev/null && echo $?
   0
-  $ ice_quiver.py --verbose postprocess   $out_dir 1>/dev/null 2>/dev/null & echo $?
+  $ ice_quiver.py --verbose postprocess   $out_dir 1>/dev/null 2>/dev/null && echo $?
   0
   $ ls $out_dir/all_quivered_hq.100_30_0.99.fasta $out_dir/all_quivered_hq.100_30_0.99.fastq $out_dir/all_quivered_lq.fasta $out_dir/all_quivered_lq.fastq 2>&1 > /dev/null && echo $?
   0


### PR DESCRIPTION
Support call to samtools version 1.3.1

SAT-463

samtools bundled with SA3.3+ has been upgraded to 1.3.1, while call to samtools 1.3.1 is different from previous versions (v 0.1.19~v 1.2).
* samtools v 0.1.19 ~ v 1.2 call: `samtools sort in.bam output_prefix`
* samtools v 1.3.1 call: `samtools sort in.bam -o output.bam`

Now pbtranscript dynamically determines samtools version and supports call to samtools versions from 0.1.19 to 1.3.1.